### PR TITLE
Add PHP server for macOS

### DIFF
--- a/chapter2/extra/hosting-options.md
+++ b/chapter2/extra/hosting-options.md
@@ -22,6 +22,10 @@ On macOS, PHP is pre-bundled with the OS and includes a nice little web server. 
 
 If you have Python3 on your machine, you can `cd` to the folder and run `python3 -m http.server` to host the HTML.
 
+If you'd rather use Python 2, you can also run `python -m SimpleHTTPServer` to host the HTML.
+
+Note that macOS already comes with Python 2 pre-installed.
+
 ### Node.js
 
 If you're going this far, you should just run the NPM based examples. Yes you can install `http-server` and run the project, but at this point you've jumped into an NPM solution, and you should run those.

--- a/chapter2/extra/hosting-options.md
+++ b/chapter2/extra/hosting-options.md
@@ -14,6 +14,10 @@ If you're using VSCode, you can serve pages directly from your your editor.
 
 Links: [Site](https://ritwickdey.github.io/vscode-live-server/) / [GitHub](https://github.com/ritwickdey/vscode-live-server) / [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
 
+### PHP
+
+On macOS, PHP is pre-bundled with the OS and includes a nice little web server. Just `cd` to the folder and run `php -S localhost:1234` to host the HTML at [http://localhost:1234](http://localhost:1234).
+
 ### Python
 
 If you have Python3 on your machine, you can `cd` to the folder and run `python3 -m http.server` to host the HTML.


### PR DESCRIPTION
I find this to be the simplest solution, if you're on a macOS. Don't have to download anything since it's built-in.