### PR TITLE
fixes Chapter 3 not having tf.unique available for testing the chapter challenge

### DIFF
--- a/chapter3/typescript/web-tensor-basics/package.json
+++ b/chapter3/typescript/web-tensor-basics/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter3/typescript/web-tensor-recommend/package.json
+++ b/chapter3/typescript/web-tensor-recommend/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter3/web/web-tensor-basics/package.json
+++ b/chapter3/web/web-tensor-basics/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter3/web/web-tensor-recommend/package.json
+++ b/chapter3/web/web-tensor-recommend/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter4/typescript/web-topixels/package-lock.json
+++ b/chapter4/typescript/web-topixels/package-lock.json
@@ -1145,73 +1145,120 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.1.0.tgz",
-      "integrity": "sha512-oQ/yOmN2LctLJEY5WNivjbIvoVj9FnxHIuTrPjrXXB7Hhk8fEzVCxP09f04r33YatOMx35OnE9tHbootGEm6eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
-        "@tensorflow/tfjs-backend-webgl": "2.1.0",
-        "@tensorflow/tfjs-converter": "2.1.0",
-        "@tensorflow/tfjs-core": "2.1.0",
-        "@tensorflow/tfjs-data": "2.1.0",
-        "@tensorflow/tfjs-layers": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
         "core-js": "3",
-        "regenerator-runtime": "^0.13.5"
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.1.0.tgz",
-      "integrity": "sha512-NXosd00L6zUztjdpxu5pBLe7CaPpi/Yvev2ik0e78TgA027tb7oHMgyB2IJI+F8BqzetWyv8Sndblmgpce98+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.1.0.tgz",
-      "integrity": "sha512-ih6qM5gTJXR96neNQ2C1Crg3NWp0Syll7iuqDAWjRpykvP8oCQ69p//I8PbCj01fMLARWs1ilekKeW/JWrWj8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.1.0.tgz",
-      "integrity": "sha512-AAKUOTRDhhbIUM++7sD+WzSw8OKmykBCLAh6iGZkil12NL90gALhTfMH+9IkI+vTybKvbNlHiSUYVWoNek7zMw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.1.0.tgz",
-      "integrity": "sha512-GFA8EkEbHYt8mRrDKrNt310Ru04Xc7HRR1nqIY7UDZ3bHpngIq+SC8WwhKSwgiGPgiTZ4N698+tqFB4eoE3uPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "node-fetch": "~2.1.2",
+        "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.1.0.tgz",
-      "integrity": "sha512-+RR/4LBqa5ylI64/Z63RVIJDH3m/0nAT3R1F55b4hmV65+Bp5+1xNZSnMQd+HOMoKcO+Q6Y7SIPb2rFGOtp4Nw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.1.2"
+        "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.1.0.tgz",
-      "integrity": "sha512-/3mdeABtRT3M5oy78aVJ2OLGcWoewWoOkmCFr0bI29SEjpsJTWJ8W94GdNtj3Ah5ssT6UyNEaiQpRTGvEmciDw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1391,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4855,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter4/typescript/web-topixels/package.json
+++ b/chapter4/typescript/web-topixels/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter4/web/web-topixels/package-lock.json
+++ b/chapter4/web/web-topixels/package-lock.json
@@ -1145,73 +1145,120 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.1.0.tgz",
-      "integrity": "sha512-oQ/yOmN2LctLJEY5WNivjbIvoVj9FnxHIuTrPjrXXB7Hhk8fEzVCxP09f04r33YatOMx35OnE9tHbootGEm6eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
-        "@tensorflow/tfjs-backend-webgl": "2.1.0",
-        "@tensorflow/tfjs-converter": "2.1.0",
-        "@tensorflow/tfjs-core": "2.1.0",
-        "@tensorflow/tfjs-data": "2.1.0",
-        "@tensorflow/tfjs-layers": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
         "core-js": "3",
-        "regenerator-runtime": "^0.13.5"
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.1.0.tgz",
-      "integrity": "sha512-NXosd00L6zUztjdpxu5pBLe7CaPpi/Yvev2ik0e78TgA027tb7oHMgyB2IJI+F8BqzetWyv8Sndblmgpce98+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.1.0.tgz",
-      "integrity": "sha512-ih6qM5gTJXR96neNQ2C1Crg3NWp0Syll7iuqDAWjRpykvP8oCQ69p//I8PbCj01fMLARWs1ilekKeW/JWrWj8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.1.0.tgz",
-      "integrity": "sha512-AAKUOTRDhhbIUM++7sD+WzSw8OKmykBCLAh6iGZkil12NL90gALhTfMH+9IkI+vTybKvbNlHiSUYVWoNek7zMw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.1.0.tgz",
-      "integrity": "sha512-GFA8EkEbHYt8mRrDKrNt310Ru04Xc7HRR1nqIY7UDZ3bHpngIq+SC8WwhKSwgiGPgiTZ4N698+tqFB4eoE3uPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "node-fetch": "~2.1.2",
+        "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.1.0.tgz",
-      "integrity": "sha512-+RR/4LBqa5ylI64/Z63RVIJDH3m/0nAT3R1F55b4hmV65+Bp5+1xNZSnMQd+HOMoKcO+Q6Y7SIPb2rFGOtp4Nw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.1.2"
+        "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.1.0.tgz",
-      "integrity": "sha512-/3mdeABtRT3M5oy78aVJ2OLGcWoewWoOkmCFr0bI29SEjpsJTWJ8W94GdNtj3Ah5ssT6UyNEaiQpRTGvEmciDw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1391,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4855,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter4/web/web-topixels/package.json
+++ b/chapter4/web/web-topixels/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter5/typescript/web-ttt-model/package-lock.json
+++ b/chapter5/typescript/web-ttt-model/package-lock.json
@@ -1145,16 +1145,16 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.6.0.tgz",
-      "integrity": "sha512-f70NAt480+/NH6ueAdKhwgN3BzeBWrvuAZ591pH44nuVlmUHtih7pSMVv2wREPOgA4ciAufops4FtTaqNamxZw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.6.0",
-        "@tensorflow/tfjs-backend-webgl": "2.6.0",
-        "@tensorflow/tfjs-converter": "2.6.0",
-        "@tensorflow/tfjs-core": "2.6.0",
-        "@tensorflow/tfjs-data": "2.6.0",
-        "@tensorflow/tfjs-layers": "2.6.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -1171,9 +1171,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1208,58 +1208,57 @@
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.6.0.tgz",
-      "integrity": "sha512-essk82VoET77tuFX5Sa9zv9F8d/2DxjEQ2RavoU+ugs0l64DTbdTpv3WdQwUihv1gNN7/16fUjJ6cG80SnS8/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.6.0.tgz",
-      "integrity": "sha512-j1eNYKIpO06CTSRXiIWdpZ2iPDBkx7PPl7K/1BtCEW/9FP7Q0q3doHKNmTdOPvuw7Dt1nNHEMnba0YB2lc5S7Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.6.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.6.0.tgz",
-      "integrity": "sha512-TzL4ULidZ26iVqfLmv5G6dfnJyJt5HttU1VZoBYCbxUcWQYk1Z4D9wqLVwfdcJz01XEKpmsECh8HBF0hwYlrkA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.6.0.tgz",
-      "integrity": "sha512-akUB1iz663UCUdOfEUu91XeHzGpdYtdtMPxjsGEdF0CwENzSAcvHzQrEVoPBRD+RKpxrVXvQBoOd7GYBxMIIKQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
         "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.6.0.tgz",
-      "integrity": "sha512-/x/j/A4Quiyc21xEYyBC82mqyssbFHRuHez7pYVJA/28TOesAfWPWo2I+wkeOTt91UerUeZMSq2FV3HOnPInhQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.6.0.tgz",
-      "integrity": "sha512-nU9WNSGpEU6GzKo5bvJBMa/OZRe1bR5Z2W6T0XiEY8CBiPNS+oJFJNm0NY8kQj/WnDS0Hfue38P46q7gV/9XMA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1439,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4903,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter5/typescript/web-ttt-model/package.json
+++ b/chapter5/typescript/web-ttt-model/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.6.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter5/web/web-ttt-model/package-lock.json
+++ b/chapter5/web/web-ttt-model/package-lock.json
@@ -1145,16 +1145,16 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.6.0.tgz",
-      "integrity": "sha512-f70NAt480+/NH6ueAdKhwgN3BzeBWrvuAZ591pH44nuVlmUHtih7pSMVv2wREPOgA4ciAufops4FtTaqNamxZw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.6.0",
-        "@tensorflow/tfjs-backend-webgl": "2.6.0",
-        "@tensorflow/tfjs-converter": "2.6.0",
-        "@tensorflow/tfjs-core": "2.6.0",
-        "@tensorflow/tfjs-data": "2.6.0",
-        "@tensorflow/tfjs-layers": "2.6.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -1171,9 +1171,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1208,58 +1208,57 @@
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.6.0.tgz",
-      "integrity": "sha512-essk82VoET77tuFX5Sa9zv9F8d/2DxjEQ2RavoU+ugs0l64DTbdTpv3WdQwUihv1gNN7/16fUjJ6cG80SnS8/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.6.0.tgz",
-      "integrity": "sha512-j1eNYKIpO06CTSRXiIWdpZ2iPDBkx7PPl7K/1BtCEW/9FP7Q0q3doHKNmTdOPvuw7Dt1nNHEMnba0YB2lc5S7Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.6.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.6.0.tgz",
-      "integrity": "sha512-TzL4ULidZ26iVqfLmv5G6dfnJyJt5HttU1VZoBYCbxUcWQYk1Z4D9wqLVwfdcJz01XEKpmsECh8HBF0hwYlrkA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.6.0.tgz",
-      "integrity": "sha512-akUB1iz663UCUdOfEUu91XeHzGpdYtdtMPxjsGEdF0CwENzSAcvHzQrEVoPBRD+RKpxrVXvQBoOd7GYBxMIIKQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
         "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.6.0.tgz",
-      "integrity": "sha512-/x/j/A4Quiyc21xEYyBC82mqyssbFHRuHez7pYVJA/28TOesAfWPWo2I+wkeOTt91UerUeZMSq2FV3HOnPInhQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.6.0.tgz",
-      "integrity": "sha512-nU9WNSGpEU6GzKo5bvJBMa/OZRe1bR5Z2W6T0XiEY8CBiPNS+oJFJNm0NY8kQj/WnDS0Hfue38P46q7gV/9XMA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1439,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4903,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter5/web/web-ttt-model/package.json
+++ b/chapter5/web/web-ttt-model/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.6.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter6/typescript/web-object-detection/package-lock.json
+++ b/chapter6/typescript/web-object-detection/package-lock.json
@@ -1145,16 +1145,16 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.7.0.tgz",
-      "integrity": "sha512-LTYK6+emFweYa3zn/o511JUR6s14/yGZpoXvFSUtdwolYHI+J50r/CyYeFpvtoTD7uwcNFQhbBAtp4L4e3Hsaw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.7.0",
-        "@tensorflow/tfjs-backend-webgl": "2.7.0",
-        "@tensorflow/tfjs-converter": "2.7.0",
-        "@tensorflow/tfjs-core": "2.7.0",
-        "@tensorflow/tfjs-data": "2.7.0",
-        "@tensorflow/tfjs-layers": "2.7.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -1171,9 +1171,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1208,20 +1208,20 @@
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.7.0.tgz",
-      "integrity": "sha512-R6ORcWq3ub81ABvBZEZ8Ok5OOT59B4AsRe66ds7B/NK0nN+k6y37bR3ZDVjgkEKNWNvzB7ydODikge3GNmgQIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.7.0.tgz",
-      "integrity": "sha512-K7Rk5YTSWOZ969EZvh3w786daPn2ub4mA2JsX7mXKhBPUaOP9dKbBdLj9buCuMcu4zVq2pAp0QwpHSa4PHm3xg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.7.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
@@ -1230,14 +1230,14 @@
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.7.0.tgz",
-      "integrity": "sha512-SBpKYn/MkN8US7DeTcnvqHpvp/WKcwzpdgkQF+eHMHEbS1lXSlt4BHhOFgRdLPzy1gEC9+6P0VdTE8NQ737t/Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.7.0.tgz",
-      "integrity": "sha512-4w5zjK6C5nkLatHpzARVQNd5QKtIocJRwjZIwWcScT9z2z1dX4rVmDoUpYg1cdD4H+yRRdI0awRaI3SL34yy8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -1247,18 +1247,18 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.7.0.tgz",
-      "integrity": "sha512-gsVklCwqqlxhykI7U2Uy5c2hjommQCAi+3y2/LER4TNtzQTzWaGKyIXvuLuL0tE896yuzXILIMZhkUjDmUiGxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.7.0.tgz",
-      "integrity": "sha512-78zsD2LLrHQuDYv0EeV83LiF0M69lKsBfuTB3FIBgS85gapZPyHh4wooKda2Y4H9EtLogU+C6bArZuDo8PaX+g=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -4902,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter6/typescript/web-object-detection/package.json
+++ b/chapter6/typescript/web-object-detection/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html basics.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.7.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0",
     "core-js": "^3.8.0",
     "regenerator-runtime": "^0.13.7"

--- a/chapter6/web/web-object-detection/package-lock.json
+++ b/chapter6/web/web-object-detection/package-lock.json
@@ -1145,16 +1145,16 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.7.0.tgz",
-      "integrity": "sha512-LTYK6+emFweYa3zn/o511JUR6s14/yGZpoXvFSUtdwolYHI+J50r/CyYeFpvtoTD7uwcNFQhbBAtp4L4e3Hsaw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.7.0",
-        "@tensorflow/tfjs-backend-webgl": "2.7.0",
-        "@tensorflow/tfjs-converter": "2.7.0",
-        "@tensorflow/tfjs-core": "2.7.0",
-        "@tensorflow/tfjs-data": "2.7.0",
-        "@tensorflow/tfjs-layers": "2.7.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -1171,9 +1171,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1208,20 +1208,20 @@
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.7.0.tgz",
-      "integrity": "sha512-R6ORcWq3ub81ABvBZEZ8Ok5OOT59B4AsRe66ds7B/NK0nN+k6y37bR3ZDVjgkEKNWNvzB7ydODikge3GNmgQIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.7.0.tgz",
-      "integrity": "sha512-K7Rk5YTSWOZ969EZvh3w786daPn2ub4mA2JsX7mXKhBPUaOP9dKbBdLj9buCuMcu4zVq2pAp0QwpHSa4PHm3xg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.7.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
@@ -1230,14 +1230,14 @@
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.7.0.tgz",
-      "integrity": "sha512-SBpKYn/MkN8US7DeTcnvqHpvp/WKcwzpdgkQF+eHMHEbS1lXSlt4BHhOFgRdLPzy1gEC9+6P0VdTE8NQ737t/Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.7.0.tgz",
-      "integrity": "sha512-4w5zjK6C5nkLatHpzARVQNd5QKtIocJRwjZIwWcScT9z2z1dX4rVmDoUpYg1cdD4H+yRRdI0awRaI3SL34yy8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -1247,18 +1247,18 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.7.0.tgz",
-      "integrity": "sha512-gsVklCwqqlxhykI7U2Uy5c2hjommQCAi+3y2/LER4TNtzQTzWaGKyIXvuLuL0tE896yuzXILIMZhkUjDmUiGxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.7.0.tgz",
-      "integrity": "sha512-78zsD2LLrHQuDYv0EeV83LiF0M69lKsBfuTB3FIBgS85gapZPyHh4wooKda2Y4H9EtLogU+C6bArZuDo8PaX+g=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -4902,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter6/web/web-object-detection/package.json
+++ b/chapter6/web/web-object-detection/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html basics.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.7.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0",
     "core-js": "^3.8.0",
     "regenerator-runtime": "^0.13.7"

--- a/chapter8/web/web-linear/package-lock.json
+++ b/chapter8/web/web-linear/package-lock.json
@@ -1145,73 +1145,120 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.1.0.tgz",
-      "integrity": "sha512-oQ/yOmN2LctLJEY5WNivjbIvoVj9FnxHIuTrPjrXXB7Hhk8fEzVCxP09f04r33YatOMx35OnE9tHbootGEm6eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
-        "@tensorflow/tfjs-backend-webgl": "2.1.0",
-        "@tensorflow/tfjs-converter": "2.1.0",
-        "@tensorflow/tfjs-core": "2.1.0",
-        "@tensorflow/tfjs-data": "2.1.0",
-        "@tensorflow/tfjs-layers": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
         "core-js": "3",
-        "regenerator-runtime": "^0.13.5"
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.1.0.tgz",
-      "integrity": "sha512-NXosd00L6zUztjdpxu5pBLe7CaPpi/Yvev2ik0e78TgA027tb7oHMgyB2IJI+F8BqzetWyv8Sndblmgpce98+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.1.0.tgz",
-      "integrity": "sha512-ih6qM5gTJXR96neNQ2C1Crg3NWp0Syll7iuqDAWjRpykvP8oCQ69p//I8PbCj01fMLARWs1ilekKeW/JWrWj8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.1.0.tgz",
-      "integrity": "sha512-AAKUOTRDhhbIUM++7sD+WzSw8OKmykBCLAh6iGZkil12NL90gALhTfMH+9IkI+vTybKvbNlHiSUYVWoNek7zMw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.1.0.tgz",
-      "integrity": "sha512-GFA8EkEbHYt8mRrDKrNt310Ru04Xc7HRR1nqIY7UDZ3bHpngIq+SC8WwhKSwgiGPgiTZ4N698+tqFB4eoE3uPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "node-fetch": "~2.1.2",
+        "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.1.0.tgz",
-      "integrity": "sha512-+RR/4LBqa5ylI64/Z63RVIJDH3m/0nAT3R1F55b4hmV65+Bp5+1xNZSnMQd+HOMoKcO+Q6Y7SIPb2rFGOtp4Nw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.1.2"
+        "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.1.0.tgz",
-      "integrity": "sha512-/3mdeABtRT3M5oy78aVJ2OLGcWoewWoOkmCFr0bI29SEjpsJTWJ8W94GdNtj3Ah5ssT6UyNEaiQpRTGvEmciDw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1391,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4855,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter8/web/web-linear/package.json
+++ b/chapter8/web/web-linear/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0"
   },
   "devDependencies": {

--- a/chapter8/web/web-non-linear/package-lock.json
+++ b/chapter8/web/web-non-linear/package-lock.json
@@ -1145,73 +1145,120 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-2.1.0.tgz",
-      "integrity": "sha512-oQ/yOmN2LctLJEY5WNivjbIvoVj9FnxHIuTrPjrXXB7Hhk8fEzVCxP09f04r33YatOMx35OnE9tHbootGEm6eA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.0.0.tgz",
+      "integrity": "sha512-8u4BGKhxJ+SHg6pWEwBqIM8Z4hdXmy3Lts8xilC1uMALoVfIActp3icUufZL5PfoXe+v7OsQe3CqC+8qTNLYoA==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
-        "@tensorflow/tfjs-backend-webgl": "2.1.0",
-        "@tensorflow/tfjs-converter": "2.1.0",
-        "@tensorflow/tfjs-core": "2.1.0",
-        "@tensorflow/tfjs-data": "2.1.0",
-        "@tensorflow/tfjs-layers": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
+        "@tensorflow/tfjs-backend-webgl": "3.0.0",
+        "@tensorflow/tfjs-converter": "3.0.0",
+        "@tensorflow/tfjs-core": "3.0.0",
+        "@tensorflow/tfjs-data": "3.0.0",
+        "@tensorflow/tfjs-layers": "3.0.0",
+        "argparse": "^1.0.10",
+        "chalk": "^4.1.0",
         "core-js": "3",
-        "regenerator-runtime": "^0.13.5"
+        "regenerator-runtime": "^0.13.5",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-2.1.0.tgz",
-      "integrity": "sha512-NXosd00L6zUztjdpxu5pBLe7CaPpi/Yvev2ik0e78TgA027tb7oHMgyB2IJI+F8BqzetWyv8Sndblmgpce98+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.0.0.tgz",
+      "integrity": "sha512-W7IX+xga007cYiFmq+QpEuDCy8SK+fsiVwawfjMFN+Dfs2FFi7JW6cHCLun/SQ5WC7dTWOhJVTwCaSBWQz6bjw==",
       "requires": {
         "@types/seedrandom": "2.4.27",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-2.1.0.tgz",
-      "integrity": "sha512-ih6qM5gTJXR96neNQ2C1Crg3NWp0Syll7iuqDAWjRpykvP8oCQ69p//I8PbCj01fMLARWs1ilekKeW/JWrWj8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.0.0.tgz",
+      "integrity": "sha512-ydgmwIMLQcX65I8CYXwuY03ShHi9atDn7WopjGb561/asWleL25kg/KfcZRQKbgbCFD3PRePvmW0ytqtXgDdpw==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "2.1.0",
+        "@tensorflow/tfjs-backend-cpu": "3.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
+        "@types/webgl2": "0.0.5",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-2.1.0.tgz",
-      "integrity": "sha512-AAKUOTRDhhbIUM++7sD+WzSw8OKmykBCLAh6iGZkil12NL90gALhTfMH+9IkI+vTybKvbNlHiSUYVWoNek7zMw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.0.0.tgz",
+      "integrity": "sha512-3Mw7gLQiG65rap8EHKaoPxaWkwjz1hH8EbsDAaatW/ez5bWFY576hdmn/dXN56XOfdvNMDJjTgXTiU6VApH6Sg=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-2.1.0.tgz",
-      "integrity": "sha512-GFA8EkEbHYt8mRrDKrNt310Ru04Xc7HRR1nqIY7UDZ3bHpngIq+SC8WwhKSwgiGPgiTZ4N698+tqFB4eoE3uPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.0.0.tgz",
+      "integrity": "sha512-bqE6q8afvXtTa21T27+/YIqwj0wvoH3leeAl8ciNvGuOVmYA69hIaDfwthSA8WsvqR0BQDK+8qDxR/BEUtmj7g==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "node-fetch": "~2.1.2",
+        "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-2.1.0.tgz",
-      "integrity": "sha512-+RR/4LBqa5ylI64/Z63RVIJDH3m/0nAT3R1F55b4hmV65+Bp5+1xNZSnMQd+HOMoKcO+Q6Y7SIPb2rFGOtp4Nw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.0.0.tgz",
+      "integrity": "sha512-pZjs8Z+7vD6Y0wnEIUP6qca4+db4C6v1lsV0QAgSqbnfOMz2QxQNorKxTqbrNP1mYkpqfxqR/5mLe+tD7gy36w==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.1.2"
+        "node-fetch": "~2.6.1"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-2.1.0.tgz",
-      "integrity": "sha512-/3mdeABtRT3M5oy78aVJ2OLGcWoewWoOkmCFr0bI29SEjpsJTWJ8W94GdNtj3Ah5ssT6UyNEaiQpRTGvEmciDw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.0.0.tgz",
+      "integrity": "sha512-nNtWXycmlEm56cFMXvTzS4Wr4rslgBbFJ6PC47Qbtl0qSfwV57qNTifDr4VOb9yCovOPiPUZGsi3FTaSr23Q5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "3.0.0",
@@ -1391,9 +1438,9 @@
       "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
     },
     "@types/webgl2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz",
-      "integrity": "sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
+      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow=="
     },
     "abab": {
       "version": "2.0.5",
@@ -4855,9 +4902,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-forge": {
       "version": "0.7.6",

--- a/chapter8/web/web-non-linear/package.json
+++ b/chapter8/web/web-non-linear/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "2.1.0",
+    "@tensorflow/tfjs": "^3.0.0",
     "@tensorflow/tfjs-node": "^3.0.0",
     "core-js": "^3.8.1",
     "regenerator-runtime": "^0.13.7"


### PR DESCRIPTION
In chapter 3 the chapter challenge is to locate in the docs the unique method, after doing this I went to test it in the chapter 3 environment and realised the unique method wasn't available in v2.1.0 - so I've bumped all the @tensorflow/tfjs deps to 3.0.0 to match their node counterparts, this should help alleviate any confusion for others.
(I notice there was a commit 10 months ago where you upgraded the other deps to 3.0.0 so I'm assuming these were missed)
