### PR TITLE
Fix issue with simple-object-localization not showing on smaller viewports

### DIFF
--- a/chapter5/simple/simple-object-localization/index.html
+++ b/chapter5/simple/simple-object-localization/index.html
@@ -6,6 +6,7 @@
   <body>
       <h1>Locate Pet Faces - TensorFlow.js</h1>
       <div style="position: relative;">
+        <!-- NOTE: styles were modified post-print to fix issues with rendering at small viewports widths -->
         <img id="pet" src="/dog1.jpg" style="width: 100%" />
         <canvas id="detection" style="position: absolute; left: 0; "></canvas>
       </div>

--- a/chapter5/simple/simple-object-localization/index.html
+++ b/chapter5/simple/simple-object-localization/index.html
@@ -3,7 +3,7 @@
   <head>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.0.0/dist/tf.min.js"></script>
   </head>
-  <body>
+  <body style="margin: 0">
     <h1>Locate Pet Faces - TensorFlow.js</h1>
     <div style="position: relative; height: 80vh">
       <img id="pet" src="/dog1.jpg" height="100%" />

--- a/chapter5/simple/simple-object-localization/index.html
+++ b/chapter5/simple/simple-object-localization/index.html
@@ -3,12 +3,12 @@
   <head>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.0.0/dist/tf.min.js"></script>
   </head>
-  <body style="margin: 0">
-    <h1>Locate Pet Faces - TensorFlow.js</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="pet" src="/dog1.jpg" height="100%" />
-      <canvas id="detection" style="position: absolute; left: 0"></canvas>
-    </div>
+  <body>
+      <h1>Locate Pet Faces - TensorFlow.js</h1>
+      <div style="position: relative;">
+        <img id="pet" src="/dog1.jpg" style="width: 100%" />
+        <canvas id="detection" style="position: absolute; left: 0; "></canvas>
+      </div>
 
     <script>
       tf.ready().then(() => {
@@ -46,5 +46,6 @@
         })
       })
     </script>
+
   </body>
 </html>

--- a/chapter5/simple/simple-object-localization/index.html
+++ b/chapter5/simple/simple-object-localization/index.html
@@ -7,7 +7,7 @@
       <h1>Locate Pet Faces - TensorFlow.js</h1>
       <div style="position: relative;">
         <!-- NOTE: styles were modified post-print to fix issues with rendering at small viewports widths -->
-        <img id="pet" src="/dog1.jpg" style="width: 100%" />
+        <img id="pet" src="/dog1.jpg" width="100%" />
         <canvas id="detection" style="position: absolute; left: 0; "></canvas>
       </div>
 

--- a/chapter6/simple/simple-object-detection/non_max.html
+++ b/chapter6/simple/simple-object-detection/non_max.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/dinner.jpg" width="100%"  />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
 

--- a/chapter6/simple/simple-object-detection/overlap.html
+++ b/chapter6/simple/simple-object-detection/overlap.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/dinner.jpg" width="100%"  />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
 

--- a/chapter6/simple/simple-object-detection/photo_finish.html
+++ b/chapter6/simple/simple-object-detection/photo_finish.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
 

--- a/chapter6/simple/simple-object-detection/too_many.html
+++ b/chapter6/simple/simple-object-detection/too_many.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
 

--- a/chapter6/simple/simple-object-detection/webcam.html
+++ b/chapter6/simple/simple-object-detection/webcam.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <video id="mystery" height="100%" autoplay></video>
+    <div style="position: relative;">
+      <video id="mystery" width="100%" autoplay></video>
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
 

--- a/chapter6/typescript/web-object-detection/basics.html
+++ b/chapter6/typescript/web-object-detection/basics.html
@@ -7,9 +7,9 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
-      <canvas id="detection" style="position: absolute; left: 0"></canvas>
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
+      <canvas id="detection" style="position: absolute; left: 0;"></canvas>
     </div>
     <div id="app"></div>
     <script src="src/basics.ts"></script>

--- a/chapter6/typescript/web-object-detection/non_max.html
+++ b/chapter6/typescript/web-object-detection/non_max.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/typescript/web-object-detection/overlap.html
+++ b/chapter6/typescript/web-object-detection/overlap.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/typescript/web-object-detection/photo_finish.html
+++ b/chapter6/typescript/web-object-detection/photo_finish.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/typescript/web-object-detection/too_many.html
+++ b/chapter6/typescript/web-object-detection/too_many.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/typescript/web-object-detection/webcam.html
+++ b/chapter6/typescript/web-object-detection/webcam.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <video id="mystery" height="100%" autoplay></video>
+    <div style="position: relative;">
+      <video id="mystery" width="100%" autoplay></video>
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/basics.html
+++ b/chapter6/web/web-object-detection/basics.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/non_max.html
+++ b/chapter6/web/web-object-detection/non_max.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative;">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/overlap.html
+++ b/chapter6/web/web-object-detection/overlap.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/photo_finish.html
+++ b/chapter6/web/web-object-detection/photo_finish.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/too_many.html
+++ b/chapter6/web/web-object-detection/too_many.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <img id="mystery" src="/static/dinner.jpg" height="100%" />
+    <div style="position: relative; ">
+      <img id="mystery" src="/static/dinner.jpg" width="100%" />
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>

--- a/chapter6/web/web-object-detection/webcam.html
+++ b/chapter6/web/web-object-detection/webcam.html
@@ -7,8 +7,8 @@
 
   <body>
     <h1>AI Sees You!</h1>
-    <div style="position: relative; height: 80vh">
-      <video id="mystery" height="100%" autoplay></video>
+    <div style="position: relative; ">
+      <video id="mystery" width="100%" autoplay></video>
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>


### PR DESCRIPTION
Due to the use of the vh on the image, at smaller width viewports the canvas doesn't draw over the image, changing `height:80vh` to `height: 100%` fixes the issue and retains previous functionality

# Current behaviour
## margin: 8 with **wide** viewport (notice whitespace to right of image)

![image](https://user-images.githubusercontent.com/17687552/147700573-77ac7ed8-7a87-41e5-a105-3d9b331302ad.png)

## margin: 8 with **small** viewport (with **no** whitespace to right of image)
![image](https://user-images.githubusercontent.com/17687552/147700598-56564f4c-0024-44c0-bca6-94c63c9fc3c0.png)

# New Behaviour
Even at small viewports the image is resized to the viewports width and therefore the bug isn't present
![image](https://user-images.githubusercontent.com/17687552/147701441-58c877f9-64cf-40e5-afa9-b5133b95be19.png)

