### PR TITLE
fix(chapter-6): incorrect script file extension for typescript examples

### DIFF
--- a/chapter6/typescript/web-object-detection/overlap.html
+++ b/chapter6/typescript/web-object-detection/overlap.html
@@ -12,6 +12,6 @@
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>
-    <script src="src/overlap.js"></script>
+    <script src="src/overlap.ts"></script>
   </body>
 </html>

--- a/chapter6/typescript/web-object-detection/package-lock.json
+++ b/chapter6/typescript/web-object-detection/package-lock.json
@@ -7389,6 +7389,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
     "uncss": {
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.3.tgz",

--- a/chapter6/typescript/web-object-detection/photo_finish.html
+++ b/chapter6/typescript/web-object-detection/photo_finish.html
@@ -12,6 +12,6 @@
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>
-    <script src="src/photo_finish.js"></script>
+    <script src="src/photo_finish.ts"></script>
   </body>
 </html>

--- a/chapter6/typescript/web-object-detection/too_many.html
+++ b/chapter6/typescript/web-object-detection/too_many.html
@@ -12,6 +12,6 @@
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>
-    <script src="src/too_many.js"></script>
+    <script src="src/too_many.ts"></script>
   </body>
 </html>

--- a/chapter6/typescript/web-object-detection/webcam.html
+++ b/chapter6/typescript/web-object-detection/webcam.html
@@ -12,6 +12,6 @@
       <canvas id="detection" style="position: absolute; left: 0"></canvas>
     </div>
     <div id="app"></div>
-    <script src="src/webcam.js"></script>
+    <script src="src/webcam.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
Back in this commit a change was made to setup the vanilla js versions again, but for chapter 6 this reverted changes where someone added typescript support for the module - in the current state parcel fails to build and the pages are inaccessible 
```
🚨  /Users/kieranosgood/learn-tfjs/chapter6/typescript/web-object-detection/src/overlap.js: ENOENT: no such file or directory, open '/Users/kieranosgood/learn-tfjs/chapter6/typescript/web-object-detection/src/overlap.js'
```
https://github.com/kieran-osgood/learn-tfjs/commit/36338df06eb824450a78343761a0ad51e786ae21